### PR TITLE
增加ntfy和gotify推送方式

### DIFF
--- a/dailycheckin/configs.py
+++ b/dailycheckin/configs.py
@@ -41,6 +41,12 @@ notice_map = {
     "TG_PROXY": "",
     "TG_USER_ID": "",
     "MERGE_PUSH": "",
+    'GOTIFY_URL': "",                   # gotify地址,如https://push.example.de:8080
+    'GOTIFY_TOKEN': "",                 # gotify的消息应用token
+    'GOTIFY_PRIORITY': "",              # 推送消息优先级,默认为0
+    'NTFY_URL': "",                     # ntfy地址,如https://ntfy.sh
+    'NTFY_TOPIC': "",                   # ntfy的消息应用topic
+    'NTFY_PRIORITY': "",                # 推送消息优先级,默认为3
 }
 
 

--- a/dailycheckin/utils/message.py
+++ b/dailycheckin/utils/message.py
@@ -301,6 +301,7 @@ def push_message(content_list: list, notice_info: dict):
             or bark_url
             or pushplus_token
             or ntfy_topic
+            or (gotify_url and gotify_token)
         ):
             merge_push = False
         else:

--- a/dailycheckin/utils/message.py
+++ b/dailycheckin/utils/message.py
@@ -300,6 +300,7 @@ def push_message(content_list: list, notice_info: dict):
             or qywx_agentid
             or bark_url
             or pushplus_token
+            or ntfy_topic
         ):
             merge_push = False
         else:

--- a/docs/pages/settings/notify/_meta.json
+++ b/docs/pages/settings/notify/_meta.json
@@ -9,5 +9,7 @@
   "qywxrobot": "企业微信群机器人",
   "telegram": "Telegram",
   "server": "Server 酱",
-  "turbo": "Server 酱 Turbo"
+  "turbo": "Server 酱 Turbo",
+  "ntfy": "Ntfy",
+  "gotify": "Gotify"
 }

--- a/docs/pages/settings/notify/bark.mdx
+++ b/docs/pages/settings/notify/bark.mdx
@@ -46,6 +46,14 @@ import { Callout } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # BARK

--- a/docs/pages/settings/notify/coolpush.mdx
+++ b/docs/pages/settings/notify/coolpush.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # CoolPush

--- a/docs/pages/settings/notify/dingtalk.mdx
+++ b/docs/pages/settings/notify/dingtalk.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # 钉钉

--- a/docs/pages/settings/notify/gotify.mdx
+++ b/docs/pages/settings/notify/gotify.mdx
@@ -1,4 +1,5 @@
 import { Cards, Card } from 'nextra/components'
+import { Callout } from 'nextra/components'
 
 <Cards>
   <Card
@@ -54,18 +55,23 @@ import { Cards, Card } from 'nextra/components'
     href="/settings/notify/gotify"
   />
 </Cards>
-# 飞书
+
+# GOTIFY
+
 
 ### 配置示例
 
 ```json filename="config.json" copy
 {
-  "FSKEY": "",
-  "MERGE_PUSH": ""
+  "GOTIFY_URL": "",
+  "GOTIFY_TOKEN": "",
+  "GOTIFY_PRIORITY": "",
 }
 ```
 
-|       参数       |                                           说明                                            |
-| :--------------: | :---------------------------------------------------------------------------------------: |
-|   _**FSKEY**_    | `https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxx` **xxxxxx** 部分就是需要填写的 FSKEY |
-| _**MERGE_PUSH**_ |                       **true**: 将推送消息合并；**false**: 分开推送                       |
+|       参数       |                                              说明                                              |
+| :--------------: | :--------------------------------------------------------------------------------------------: |
+|  _**GOTIFY_URL**_  | [GOTIFY] ,填写 `GOTIFY_URL`                                                                  |
+|  _**GOTIFY_TOKEN**_|                           填写 `GOTIFY_TOKEN`                                                |
+| _**GOTIFY_PRIORITY**_|                          填写 `GOTIFY_PRIORITY`                                            |
+| _**MERGE_PUSH**_ |                         **true**: 将推送消息合并；**false**: 分开推送                            |

--- a/docs/pages/settings/notify/ntfy.mdx
+++ b/docs/pages/settings/notify/ntfy.mdx
@@ -1,4 +1,5 @@
 import { Cards, Card } from 'nextra/components'
+import { Callout } from 'nextra/components'
 
 <Cards>
   <Card
@@ -54,18 +55,23 @@ import { Cards, Card } from 'nextra/components'
     href="/settings/notify/gotify"
   />
 </Cards>
-# 飞书
+
+# NTFY
+
 
 ### 配置示例
 
 ```json filename="config.json" copy
 {
-  "FSKEY": "",
-  "MERGE_PUSH": ""
+  "NTFY_URL": "",
+  "NTFY_TOPIC": "",
+  "NTFY_PRIORITY": "",
 }
 ```
 
-|       参数       |                                           说明                                            |
-| :--------------: | :---------------------------------------------------------------------------------------: |
-|   _**FSKEY**_    | `https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxx` **xxxxxx** 部分就是需要填写的 FSKEY |
-| _**MERGE_PUSH**_ |                       **true**: 将推送消息合并；**false**: 分开推送                       |
+|       参数       |                                              说明                                              |
+| :--------------: | :--------------------------------------------------------------------------------------------: |
+|  _**NTFY_URL**_  | [NTFY](https://ntfy.sh) ,填写 `NTFY_URL` 例: `https://ntfy.sh` 也可以自建服务端                  |
+|  _**NTFY_TOPIC**_|                           填写 `NTFY_TOPIC` 例: `dailycheckin`                                 |
+| _**NTFY_PRIORITY**_|                          填写 `NTFY_PRIORITY` 例: `3`, 默认为3                               |
+| _**MERGE_PUSH**_ |                         **true**: 将推送消息合并；**false**: 分开推送                            |

--- a/docs/pages/settings/notify/pushplus.mdx
+++ b/docs/pages/settings/notify/pushplus.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # PushPlus

--- a/docs/pages/settings/notify/qmsg.mdx
+++ b/docs/pages/settings/notify/qmsg.mdx
@@ -46,6 +46,14 @@ import { Callout } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # Qmsg 酱

--- a/docs/pages/settings/notify/qywx.mdx
+++ b/docs/pages/settings/notify/qywx.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # 企业微信应用消息

--- a/docs/pages/settings/notify/qywxrobot.mdx
+++ b/docs/pages/settings/notify/qywxrobot.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # 企业微信群机器人

--- a/docs/pages/settings/notify/server.mdx
+++ b/docs/pages/settings/notify/server.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # Server 酱

--- a/docs/pages/settings/notify/telegram.mdx
+++ b/docs/pages/settings/notify/telegram.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # Telegram

--- a/docs/pages/settings/notify/turbo.mdx
+++ b/docs/pages/settings/notify/turbo.mdx
@@ -45,6 +45,14 @@ import { Cards, Card } from 'nextra/components'
     title="Server 酱 TURBO"
     href="/settings/notify/turbo"
   />
+  <Card
+    title="Ntfy"
+    href="/settings/notify/ntfy"
+  />
+  <Card
+    title="Gotify"
+    href="/settings/notify/gotify"
+  />
 </Cards>
 
 # Server 酱 TURBO


### PR DESCRIPTION
 #448 
 # 增添两条通知渠道
 在源代码基础上添加两条通知渠道；
 * [Ntfy](https://www.ntfy.sh)
 * [Gotify](https://gotify.net/)
# 新增文档

# 新增参数

- GOTIFY_URL                 # gotify地址,如https://push.example.de:8080
- GOTIFY_TOKEN            # gotify的消息应用token
- GOTIFY_PRIORITY        # 推送消息优先级,默认为0
- NTFY_URL                    # ntfy地址,如https://ntfy.sh
- NTFY_TOPIC                 # ntfy的消息应用topic
- NTFY_PRIORITY           # 推送消息优先级,默认为3    