### PR TITLE
fix(enshan): avoid WAF 521 by not forcing Accept/UA

### DIFF
--- a/dailycheckin/enshan/main.py
+++ b/dailycheckin/enshan/main.py
@@ -49,8 +49,6 @@ class EnShan(CheckIn):
         response = session.post(
             "https://www.right.com.cn/forum/plugin.php?id=erling_qd:action&action=sign",
             headers={
-                "Accept": "application/json, text/javascript, */*; q=0.01",
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
                 "X-Requested-With": "XMLHttpRequest",
             },
             data=payload,
@@ -91,7 +89,7 @@ class EnShan(CheckIn):
     def get_info(session):
         msg = []
         response = session.get(
-            "https://www.right.com.cn/FORUM/home.php?mod=spacecp&ac=credit&showcredit=1",
+            "https://www.right.com.cn/forum/home.php?mod=spacecp&ac=credit&showcredit=1",
             headers={"Accept": EnShan._HTML_ACCEPT},
             timeout=15,
         )

--- a/dailycheckin/enshan/main.py
+++ b/dailycheckin/enshan/main.py
@@ -13,13 +13,21 @@ urllib3.disable_warnings()
 class EnShan(CheckIn):
     name = "恩山无线论坛"
 
+    # 说明：right.com.cn 站点存在 WAF；在实测中，部分 Chrome/Windows UA 会触发 521。
+    # 因此这里避免在 Session 级别强行覆盖请求头；GET 页面时尽量使用浏览器常见的 Accept(text/html)。
+    _HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+
     def __init__(self, check_item):
         self.check_item = check_item
 
     @staticmethod
     def get_formhash_from_page(session):
         """GET 签到页面并提取 formhash Discuz 常见的 CSRF 字段"""
-        response = session.get("https://www.right.com.cn/forum/forum.php", timeout=15)
+        response = session.get(
+            "https://www.right.com.cn/forum/forum.php",
+            headers={"Accept": EnShan._HTML_ACCEPT},
+            timeout=15,
+        )
         response.raise_for_status()
         html = response.text
         # 常见两种位置：隐藏 input name="formhash" value="..." 或 js var formhash = '...'
@@ -39,7 +47,14 @@ class EnShan(CheckIn):
         msg = []
         payload = {"formhash": form_hash}
         response = session.post(
-            "https://www.right.com.cn/forum/plugin.php?id=erling_qd:action&action=sign", data=payload, timeout=15
+            "https://www.right.com.cn/forum/plugin.php?id=erling_qd:action&action=sign",
+            headers={
+                "Accept": "application/json, text/javascript, */*; q=0.01",
+                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "X-Requested-With": "XMLHttpRequest",
+            },
+            data=payload,
+            timeout=15,
         )
         try:
             data = response.json()
@@ -75,7 +90,11 @@ class EnShan(CheckIn):
     @staticmethod
     def get_info(session):
         msg = []
-        response = session.get("https://www.right.com.cn/FORUM/home.php?mod=spacecp&ac=credit&showcredit=1", timeout=15)
+        response = session.get(
+            "https://www.right.com.cn/FORUM/home.php?mod=spacecp&ac=credit&showcredit=1",
+            headers={"Accept": EnShan._HTML_ACCEPT},
+            timeout=15,
+        )
         response.raise_for_status()
         html = response.text
         try:
@@ -105,10 +124,7 @@ class EnShan(CheckIn):
         session = requests.Session()
         session.headers.update(
             {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
-                "Accept": "application/json, text/javascript, */*; q=0.01",
                 "Referer": "https://www.right.com.cn/forum/",
-                "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
                 "Cookie": cookie,
             }
         )


### PR DESCRIPTION
## 背景
right.com.cn 近期有 WAF 行为；实测在某些 User-Agent/Accept 组合下会返回 521（即使 cookie 正确）。

## 变更
- 不再在 Session 级别强制设置 UA/Accept，避免触发 WAF 的特征匹配。
- GET 页面请求显式带浏览器常见的 `Accept: text/html,...`，用于拉取签到页并解析 `formhash` / 个人积分页。
- 签到 POST 仅保留必要的 `X-Requested-With: XMLHttpRequest`，其余交给 requests 默认行为。

## 影响范围
仅影响 enshan（恩山无线论坛）模块的请求头策略；不引入新依赖，不改变业务流程。

## 风险
- 如果站点后续强依赖某些 header（如严格要求 JSON Accept），可能需要再加回；目前以最小 header 集合优先。
